### PR TITLE
投稿を1時間で非表示にする

### DIFF
--- a/styles/NewPost.module.css
+++ b/styles/NewPost.module.css
@@ -20,6 +20,7 @@
   border-radius: 6px;
   font-size: 1rem;
   margin-bottom: 8px;
+  letter-spacing: normal;
 }
 
 .charCount {

--- a/styles/PostDetail.module.css
+++ b/styles/PostDetail.module.css
@@ -135,6 +135,7 @@
   border-radius: 6px;
   font-size: 1rem;
   resize: vertical;
+  letter-spacing: normal;
 }
 .charCount {
   font-size: 0.875rem;


### PR DESCRIPTION
Add `letter-spacing: normal;` to textareas to fix wide character spacing for full-width characters in input fields.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec) · [Cursor](https://cursor.com/background-agent?bcId=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)