### PR TITLE
投稿を1時間で非表示にする

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -23,7 +23,7 @@ export const authOptions: AuthOptions = {
         email: { label: "メールアドレス", type: "email" },
         password: { label: "パスワード", type: "password" },
       },
-      async authorize(credentials) {
+      async authorize(credentials, req) {
         if (!credentials?.email || !credentials?.password) {
           throw new Error("メールアドレスとパスワードは必須です");
         }


### PR DESCRIPTION
Add email/password authentication to allow account creation and posting without Google account linking.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec) · [Cursor](https://cursor.com/background-agent?bcId=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)