### PR TITLE
投稿を1時間で非表示にする

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -25,7 +25,7 @@ export const authOptions: AuthOptions = {
       },
       async authorize(credentials, req) {
         if (!credentials?.email || !credentials?.password) {
-          throw new Error("メールアドレスとパスワードは必須です");
+          return null;
         }
         // DynamoDBからユーザー取得
         const result = await client.send(
@@ -35,15 +35,15 @@ export const authOptions: AuthOptions = {
           })
         );
         if (!result.Item) {
-          throw new Error("ユーザーが見つかりません");
+          return null;
         }
         const user = unmarshall(result.Item);
         if (!user.password) {
-          throw new Error("このアカウントはGoogle認証専用です");
+          return null;
         }
         const isValid = await bcrypt.compare(credentials.password, user.password);
         if (!isValid) {
-          throw new Error("パスワードが違います");
+          return null;
         }
         return { id: user.userId, email: user.email, username: user.username };
       },


### PR DESCRIPTION
Fix `TypeError` in `next-auth` Credentials Provider by returning `null` on authentication failure.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec) · [Cursor](https://cursor.com/background-agent?bcId=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)