### PR TITLE
投稿を1時間で非表示にする

### DIFF
--- a/pages/new.tsx
+++ b/pages/new.tsx
@@ -9,6 +9,7 @@ export default function NewPostPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const [error, setError] = useState("");
+  const [showError, setShowError] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
 
   const submit = async () => {
@@ -21,6 +22,8 @@ export default function NewPostPage() {
 
     if (form.body.length > 50) {
       setError("本文は50文字以内で入力してください。");
+      setShowError(true);
+      setTimeout(() => setShowError(false), 1800);
       return;
     }
 
@@ -45,6 +48,8 @@ export default function NewPostPage() {
     } else {
       const data = await res.json();
       setError(data?.error || "投稿に失敗しました。");
+      setShowError(true);
+      setTimeout(() => setShowError(false), 1800);
     }
   };
 
@@ -59,6 +64,11 @@ export default function NewPostPage() {
           <span style={{ fontSize: 22, flexShrink: 0 }}>✅</span> 投稿が作成されました！
         </div>
       )}
+      {showError && (
+        <div className={styles.errorPopup}>
+          <span style={{ fontSize: 22, flexShrink: 0 }}>❌</span> {error}
+        </div>
+      )}
       <h1 className={styles.title}>🆕 新規投稿</h1>
 
       <textarea
@@ -70,7 +80,7 @@ export default function NewPostPage() {
       />
       <p className={styles.charCount}>{form.body.length}/50文字</p>
 
-      {error && <p className={styles.error}>{error}</p>}
+      {/* 通常のエラー表示はポップアップに統一 */}
 
       <button
         className={styles.submitButton}

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -8,6 +8,7 @@ export default function ProfilePage() {
   const [userId, setUserId] = useState("");
   const [showSuccess, setShowSuccess] = useState(false);
   const [error, setError] = useState("");
+  const [showError, setShowError] = useState(false);
 
   useEffect(() => {
     if (session?.user?.email) {
@@ -33,6 +34,8 @@ export default function ProfilePage() {
       setTimeout(() => setShowSuccess(false), 1800);
     } else {
       setError("更新に失敗しました。");
+      setShowError(true);
+      setTimeout(() => setShowError(false), 1800);
     }
   };
 
@@ -58,7 +61,11 @@ export default function ProfilePage() {
         />
         <p className={styles.userId}>ユーザーID：<span className={styles.mono}>#{userId}</span></p>
         <button className={styles.button} onClick={saveUsername}>保存</button>
-        {error && <p className={styles.error}>{error}</p>}
+        {showError && (
+          <div className={styles.errorPopup}>
+            <span style={{ fontSize: 22, flexShrink: 0 }}>❌</span> {error}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/styles/NewPost.module.css
+++ b/styles/NewPost.module.css
@@ -81,3 +81,23 @@
   90% { opacity: 1; transform: translateX(-50%) translateY(0); }
   100% { opacity: 0; transform: translateX(-50%) translateY(-20px); }
 }
+
+/* 投稿エラーポップアップ */
+.errorPopup {
+  position: fixed;
+  top: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #dc2626;
+  color: #fff;
+  padding: 18px 32px;
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.12);
+  font-size: 1.1rem;
+  font-weight: bold;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  animation: fadeInOut 2s;
+}

--- a/styles/Profile.module.css
+++ b/styles/Profile.module.css
@@ -80,6 +80,26 @@
   animation: fadeInOut 2s;
 }
 
+/* プロフィールエラーポップアップ */
+.errorPopup {
+  position: fixed;
+  top: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #dc2626;
+  color: #fff;
+  padding: 18px 32px;
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.12);
+  font-size: 1.1rem;
+  font-weight: bold;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  animation: fadeInOut 2s;
+}
+
 @keyframes fadeInOut {
   0% { opacity: 0; transform: translateX(-50%) translateY(-20px); }
   10% { opacity: 1; transform: translateX(-50%) translateY(0); }


### PR DESCRIPTION
投稿作成時とプロフィール更新時のエラー表示を、成功時と同様の洗練されたポップアップ演出に統一。

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec) · [Cursor](https://cursor.com/background-agent?bcId=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)