### PR TITLE
投稿を1時間で非表示にする

### DIFF
--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -3,7 +3,7 @@ import { useSession } from "next-auth/react";
 import styles from "../styles/Profile.module.css";
 
 export default function ProfilePage() {
-  const { data: session } = useSession();
+  const { data: session, update } = useSession();
   const [username, setUsername] = useState("");
   const [userId, setUserId] = useState("");
   const [showSuccess, setShowSuccess] = useState(false);
@@ -32,6 +32,8 @@ export default function ProfilePage() {
     if (res.ok) {
       setShowSuccess(true);
       setTimeout(() => setShowSuccess(false), 1800);
+      // セッション情報を更新
+      await update({ ...session, user: { ...session?.user, username } });
     } else {
       setError("更新に失敗しました。");
       setShowError(true);


### PR DESCRIPTION
Update NavBar username display and add favicon to reflect profile changes and set site identity.

The NavBar's username was not updating after profile changes because the `next-auth` session was not automatically refreshed. This PR calls `useSession().update()` after a successful profile save to force a re-fetch of the latest user data, ensuring the NavBar displays the correct, updated username.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec) · [Cursor](https://cursor.com/background-agent?bcId=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)