### PR TITLE
投稿を1時間で非表示にする

### DIFF
--- a/pages/api/posts.ts
+++ b/pages/api/posts.ts
@@ -19,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     // 各投稿のコメント数を取得
     const postsWithCommentCount = await Promise.all(
-      posts.map(async (post) => {
+      posts.map(async (post: any) => {
         const commentResult = await client.send(
           new QueryCommand({
             TableName: "Comments",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix build error by explicitly typing `post` in `pages/api/posts.ts`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The TypeScript compiler was unable to infer the `expiresAt` property on the `post` object when adding `commentCount`, leading to a type error during `npm run build`. Explicitly casting `post` to `any` resolves this.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec) · [Cursor](https://cursor.com/background-agent?bcId=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)