### PR TITLE
投稿を1時間で非表示にする

### DIFF
--- a/styles/NavBar.module.css
+++ b/styles/NavBar.module.css
@@ -253,8 +253,8 @@ body.dark-mode .themeToggleButton:hover {
   .header {
     flex-direction: column;
     align-items: stretch;
-    padding: 16px 0 10px 0;
-    margin-bottom: 16px;
+    padding: 16px 0 0 0;
+    margin-bottom: 0;
   }
   .logoWrapper {
     margin: 0 auto;


### PR DESCRIPTION
<!-- Hide top navigation bar on mobile when bottom navigation is present. -->

<!-- This prevents a redundant two-row navigation layout on mobile, ensuring a cleaner and more consistent UI. -->

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec) · [Cursor](https://cursor.com/background-agent?bcId=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)