### PR TITLE
投稿を1時間で非表示にする

### DIFF
--- a/pages/api/posts.ts
+++ b/pages/api/posts.ts
@@ -35,7 +35,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       })
     );
     const now = Math.floor(Date.now() / 1000);
-    const filtered = postsWithCommentCount?.filter((item) => !item.expiresAt || item.expiresAt > now);
+    let filtered = postsWithCommentCount;
+    if (!req.query.all) {
+      filtered = postsWithCommentCount?.filter((item) => !item.expiresAt || item.expiresAt > now);
+    }
     res.status(200).json(filtered);
   } catch (err) {
     console.error(err);

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -26,7 +26,7 @@ export default function ProfilePage({ toggleTheme, theme }: { toggleTheme: () =>
   // 自分の投稿（過去24時間分のみ）を取得
   useEffect(() => {
     if (!userId) return;
-    fetch("/api/posts")
+    fetch("/api/posts?all=1")
       .then((res) => res.json())
       .then((data) => {
         const now = Date.now();


### PR DESCRIPTION
Rename "Profile Settings" to "My Page" and add a feature to view the user's own posts from the last 24 hours on the My Page.

The API was adjusted to allow fetching all posts for My Page, enabling client-side filtering for the 24-hour display.

---

[Open in Web](https://www.cursor.com/agents?id=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f4b28e40-23fe-45bc-9dbd-9a6d909563ec)